### PR TITLE
fix: place holes by html context, not nearest angle bracket

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,13 +8,16 @@ export let html = (s, ...v) => ({ s, v });
 let compile = (strings) => {
   let markup = "";
   let inTag = false;
+  let quote = "";
 
   strings.forEach((s, index) => {
-    let open = s.lastIndexOf("<");
-    let close = s.lastIndexOf(">");
-
-    /* neither found? stay where the last chunk left us */
-    if (open !== close) inTag = open > close;
+    /* where the last chunk left us. a "<" that opens no tag is text, a quoted ">" closes no tag */
+    for (let c of s.replace(/<(?![a-z!/?])/gi, "")) {
+      if (quote) quote = c === quote ? "" : quote;
+      else if (!inTag) inTag = c === "<";
+      else if (c === ">") inTag = false;
+      else if (c === '"' || c === "'") quote = c;
+    }
 
     markup += s + (index < strings.length - 1 ? (inTag ? MARK : `<!--${MARK}-->`) : "");
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -238,7 +238,7 @@ class FalsyPropParent extends Nho {
 
 class TrailingEqualsElement extends Nho {
   render(h) {
-    return h`<p title=${"t"}>n=${1} a=${2}</p>`;
+    return h`<p title=${"t"} lang="a > ${"en"}">n=${1} a=${2}; 1 < 2, it's ${"fine"}</p>`;
   }
 }
 
@@ -515,6 +515,13 @@ it("should treat text ending in = as text, not as an attribute", () => {
 
   expect(p.getAttribute("title")).toBe("t");
   expect(p).toHaveTextContent("n=1 a=2");
+});
+
+it("should place holes by html context, not by the nearest angle bracket", () => {
+  const p = mount("trailing-equals").shadowRoot.querySelector("p");
+
+  expect(p.getAttribute("lang")).toBe("a > en");
+  expect(p).toHaveTextContent("1 < 2, it's fine");
 });
 
 it("should render and update lists", async () => {


### PR DESCRIPTION
Closes #3

## The bug

`compile()` decided whether a `${}` hole landed inside a tag by comparing `s.lastIndexOf("<")` against `s.lastIndexOf(">")` in the preceding static chunk. That is a positional guess with no HTML tokenizer state, so both reported cases fooled it:

- `<p>1 < 2; score = ${7}` — the last `<` is the literal in the text, so `open > close` and the hole got the bare attribute sentinel. Nothing reads a sentinel in text position, so it rendered as `$nho$`.
- `<div title="Score > ${7}">` — the last `>` sits inside the quoted attribute value, so the tag looked closed and the hole got a comment anchor. The parser read it as attribute text, giving `Score > <!--7-->`.

## The fix

Track `inTag` and `quote` across chunks instead of guessing from positions. Quotes hide `>`, and a `<` opens a tag only when followed by `[a-z!/?]`, which is what the HTML tokenizer does.

```js
for (let c of s.replace(/<(?![a-z!/?])/gi, "")) {
  if (quote) quote = c === quote ? "" : quote;
  else if (!inTag) inTag = c === "<";
  else if (c === ">") inTag = false;
  else if (c === '"' || c === "'") quote = c;
}
```

## Verification

- New regression test at `test/index.test.js`, covering both reported cases plus an apostrophe in text. The apostrophe is deliberate: it separates a correct fix from a quote tracker that also runs outside tags.
- A 17-case battery of realistic templates was run against old and new code. The old code failed 5; the new code passes all 17, with no regressions.
- Confirmed still correct: apostrophes and double quotes in text, `"` nested inside a `'`-quoted attribute, unquoted attribute holes, boolean attributes, closing tags, self-closing SVG, and multiple attributes each carrying a hole.
- `bun test` 37/37, biome clean, 100% line coverage on `src/index.js`.

## Size

1385 -> 1424 bytes gzipped (+39). Four scanner shapes were benchmarked; the two cheaper ones either weaken the state machine or, in the folded-state case, compress worse. This is within 4 bytes of the smallest correct variant found.

## Known limitation (pre-existing, unchanged)

A hole inside an HTML comment (`<!-- ${x} -->`) still emits the raw sentinel. `main` behaves identically, so this is not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qgni6KcJYzyg1N9BhvKmm8