### PR TITLE
fix: renderer lifecycle, list order, ref lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ flowchart LR
 - HTML lowercases names — `onBuy=${fn}` arrives as `props.onbuy`.
 - Bare host attributes are `""` — `<my-el done>` is falsy, use `done="yes"`.
 - No holes in `<style>` or `<textarea>` — use `Nho.style`.
+- Holes go in text or in an attribute value — not in a tag name (`<${tag}>`), an attribute name (`<p ${attr}>`), or an HTML comment.
+- Host attributes are read once at mount — change props from the parent, not with `setAttribute`.
 - Only `setState` re-renders, and it merges shallowly — replace nested objects and arrays, never mutate.
 - Falsy follows React — `null` `undefined` `true` `false` render nothing, `0` renders.
 - Text holes take primitives — a plain object with an `s` key reads as a template.

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "files": ["dist", "src", "*.md"],
   "scripts": {
     "build": "bun run build:module && bun run build:umd && bun run size",
-    "build:module": "esbuild src/index.js --bundle --minify --format=esm --target=es2022 --outfile=dist/index.es.js",
-    "build:umd": "esbuild src/umd.js --bundle --minify --format=iife --target=es2022 --outfile=dist/index.umd.js",
+    "build:module": "esbuild src/index.js --bundle --minify --mangle-props=^_ --format=esm --target=es2022 --outfile=dist/index.es.js",
+    "build:umd": "esbuild src/umd.js --bundle --minify --mangle-props=^_ --format=iife --target=es2022 --outfile=dist/index.umd.js",
     "size": "for f in dist/*.js; do echo \"$f: $(wc -c <\"$f\") raw, $(gzip -c \"$f\" | wc -c) gzip\"; done",
     "build:example": "bun build ./example/index.html --outdir=example/dist --minify",
     "coverage": "bun test --coverage",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 let cache = new WeakMap();
-let MARK = "$nho$";
+let MARK = "$n$";
 
 /* capture, parse nothing. "s" marks a template */
 export let html = (s, ...v) => ({ s, v });
@@ -74,7 +74,7 @@ let instantiate = (strings) => {
 
 /* text hole: text, a nested template, or a list of either */
 let setChild = (inst, k, anchor, value, host) => {
-  let list = Array.isArray(value) ? value : [value];
+  let list = [value].flat();
   let state = inst.c[k] || (inst.c[k] = []);
 
   /* drop what the new value dropped */
@@ -89,7 +89,7 @@ let setChild = (inst, k, anchor, value, host) => {
     if (child && child[0] === strings) {
       if (strings) return update(child[1], item.v, host);
 
-      child[2][0].data = item == null || item === true || item === false ? "" : item;
+      child[2][0].data = item == null || item === !!item ? "" : item;
 
       return;
     }
@@ -97,13 +97,15 @@ let setChild = (inst, k, anchor, value, host) => {
     if (child) child[2].forEach((node) => node.remove());
 
     let nested = strings && instantiate(strings);
-    let node = nested ? nested.r : document.createTextNode(item == null || item === true || item === false ? "" : item);
-
-    /* fragment empties on insert, remember its children first */
-    let nodes = nested ? [...nested.r.childNodes] : [node];
+    let node = nested ? nested.r : document.createTextNode(item == null || item === !!item ? "" : item);
 
     if (nested) update(nested, item.v, host);
-    anchor.before(node);
+
+    /* fragment empties on insert, remember its children first. holes are filled by now, so they count */
+    let nodes = nested ? [...nested.r.childNodes] : [node];
+
+    /* the next item is still where it was, put the new node in front of it */
+    (state[index + 1]?.[2][0] ?? anchor).before(node);
     state[index] = [strings, nested, nodes];
   });
 };
@@ -126,6 +128,7 @@ let update = (inst, values, host) => {
       return;
     }
 
+    let before = inst.l[part.h];
     let changed = false;
     for (let i = 0; i < part.c; i++) {
       if (values[part.h + i] !== inst.l[part.h + i]) changed = true;
@@ -141,17 +144,19 @@ let update = (inst, values, host) => {
     let value =
       part.c === 1 && !part.s[0] && !part.s[1]
         ? values[part.h]
-        : part.s.reduce((acc, s, i) => acc + values[part.h + i - 1] + s);
+        : part.s.reduce((acc, s, i) => acc + (values[part.h + i - 1] ?? "") + s);
 
     /* on a custom element every "on*" is a prop, so onClose reaches the child, not HTMLElement's onclose */
-    if (name === "ref") value.current = node;
-    else if (part.o) {
+    if (name === "ref") {
+      if (before && before !== value) before.current = null;
+      if (value) value.current = node;
+    } else if (part.o) {
       /* bound to the owner, like an inline handler */
-      (node.props ??= {})[name] = value instanceof Function ? value.bind(host) : value;
+      (node.props ??= {})[name] = typeof value === "function" ? value.bind(host) : value;
 
       /* an object can hold new contents under the same identity, a function cannot */
       if (changed || (value && typeof value === "object")) node._s?.();
-    } else if (name.startsWith("on") && name in node) node[name] = value ? value.bind(host) : null;
+    } else if (/^on/.test(name) && name in node) node[name] = value ? value.bind(host) : null;
     else if (value == null || value === false) node.removeAttribute(name);
     else node.setAttribute(name, value);
   });
@@ -187,7 +192,7 @@ export class Nho extends HTMLElement {
 
   disconnectedCallback() {
     /* drop the pending update, must not run after unmount */
-    cancelAnimationFrame(this._t);
+    this._t = cancelAnimationFrame(this._t);
 
     this.onUnmounted?.();
   }
@@ -195,17 +200,21 @@ export class Nho extends HTMLElement {
   /* update */
   _u() {
     let result = this.render(html);
-    let first = !this._i;
 
-    if (first) this._i = instantiate(result.s);
+    /* a different template means a different skeleton, holes do not line up */
+    let first = this._k !== result.s;
+
+    /* the old skeleton is about to go, its refs point at nothing */
+    if (first && this._i) this._i.p.forEach((p) => p.n === "ref" && this._i.l[p.h] && (this._i.l[p.h].current = null));
+
+    if (first) {
+      this._sr.innerHTML = Nho.style ? `<style>${Nho.style}</style>` : "";
+      this._i = instantiate((this._k = result.s));
+    }
 
     update(this._i, result.v, this);
 
-    if (first) {
-      if (Nho.style) this._sr.innerHTML = `<style>${Nho.style}</style>`;
-
-      this._sr.append(this._i.r);
-    }
+    if (first) this._sr.append(this._i.r);
 
     this.onUpdated?.();
 
@@ -223,7 +232,9 @@ export class Nho extends HTMLElement {
     if (!this._t)
       this._t = requestAnimationFrame(() => {
         this._t = 0;
-        this._u();
+
+        /* removed while the frame was pending, or asked by a parent after removal */
+        if (this.isConnected) this._u();
       });
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -297,6 +297,96 @@ class SetupCountElement extends Nho {
   }
 }
 
+class SwapRootElement extends Nho {
+  setup() {
+    this.state = { loading: true };
+  }
+
+  render(h) {
+    return this.state.loading ? h`<p>loading</p>` : h`<div class=${"done"}>${"ready"}</div>`;
+  }
+}
+
+class SwapItemElement extends Nho {
+  setup() {
+    this.state = { rich: false };
+  }
+
+  render(h) {
+    return h`<div>${["a", this.state.rich ? h`<i>b</i>` : "b", "c"]}</div>`;
+  }
+}
+
+class NullishPartElement extends Nho {
+  setup() {
+    this.state = { note: null, target: null };
+  }
+
+  render(h) {
+    return h`<p ref=${this.state.target} class="box ${this.state.note}"></p>`;
+  }
+}
+
+class HoleFirstListElement extends Nho {
+  setup() {
+    this.state = { swap: false, items: ["x", "y"] };
+  }
+
+  render(h) {
+    return h`<div>${[this.state.swap ? h`<b>A</b>` : "A", ...this.state.items.map((i) => h`${i}<i>-</i>`)]}</div>`;
+  }
+}
+
+class ZombieElement extends Nho {
+  setup() {
+    this.state = { count: 0 };
+    this.updates = 0;
+    this.effects = 0;
+
+    this.effect(
+      () => this.state.count,
+      () => this.effects++,
+    );
+  }
+
+  onUpdated() {
+    this.updates++;
+  }
+
+  render(h) {
+    return h`<p>${this.state.count}</p>`;
+  }
+}
+
+class RefSwapElement extends Nho {
+  setup() {
+    this.state = { on: true };
+    this.target = this.ref();
+  }
+
+  render(h) {
+    return this.state.on ? h`<p ref=${this.target}>on</p>` : h`<div>off</div>`;
+  }
+}
+
+class RefDropElement extends Nho {
+  setup() {
+    this.state = { keep: true };
+    this.target = this.ref();
+  }
+
+  render(h) {
+    return h`<p ref=${this.state.keep ? this.target : null}>x</p>`;
+  }
+}
+
+customElements.define("hole-first-list", HoleFirstListElement);
+customElements.define("zombie-element", ZombieElement);
+customElements.define("ref-swap", RefSwapElement);
+customElements.define("ref-drop", RefDropElement);
+customElements.define("swap-root", SwapRootElement);
+customElements.define("swap-item", SwapItemElement);
+customElements.define("nullish-part", NullishPartElement);
 customElements.define("parent-element", ParentElement);
 customElements.define("child-element", ChildElement);
 customElements.define("ref-element", RefElement);
@@ -700,4 +790,110 @@ it("should run setup only once when the element is moved", async () => {
   expect(element.setupCount).toBe(1);
   expect(element.state.count).toBe(5);
   expect(element.props).toBe(props);
+});
+
+it("should re-instantiate when render returns a different template", async () => {
+  const element = mount("swap-root");
+
+  expect(element.shadowRoot.querySelector("p")).toHaveTextContent("loading");
+
+  element.setState({ loading: false });
+  await tick();
+
+  const node = element.shadowRoot.querySelector("div");
+
+  expect(node).toHaveTextContent("ready");
+  expect(node.getAttribute("class")).toBe("done");
+  expect(element.shadowRoot.querySelector("style")).toBeInTheDocument();
+});
+
+it("should keep list order when an item changes shape", async () => {
+  const element = mount("swap-item");
+
+  element.setState({ rich: true });
+  await tick();
+
+  expect(element.shadowRoot.querySelector("div")).toHaveTextContent("abc");
+  expect(element.shadowRoot.querySelector("i")).toHaveTextContent("b");
+});
+
+it("should keep updating after the element is moved in the dom", async () => {
+  const element = mount("setup-count");
+  const box = document.createElement("div");
+
+  document.body.appendChild(box);
+
+  /* move while a frame is pending: the move must not leave the scheduler stuck */
+  element.setState({ count: 7 });
+  box.appendChild(element);
+  await tick();
+
+  expect(element.shadowRoot.querySelector("p")).toHaveTextContent("7");
+
+  element.setState({ count: 3 });
+  await tick();
+
+  expect(element.shadowRoot.querySelector("p")).toHaveTextContent("3");
+});
+
+it("should ignore a nullish ref and skip nullish attribute parts", () => {
+  const element = mount("nullish-part");
+  const p = element.shadowRoot.querySelector("p");
+
+  /* jsdom reports a throw inside the reaction instead of propagating it, so the render itself is the assertion */
+  expect(p).toBeInTheDocument();
+  expect(p.getAttribute("class")).toBe("box ");
+});
+
+it("should keep list order when the next item starts with a hole", async () => {
+  const element = mount("hole-first-list");
+
+  expect(element.shadowRoot.querySelector("div").textContent).toBe("Ax-y-");
+
+  element.setState({ swap: true });
+  await tick();
+
+  expect(element.shadowRoot.querySelector("div").textContent).toBe("Ax-y-");
+  expect(element.shadowRoot.querySelector("b")).toHaveTextContent("A");
+});
+
+it("should remove every node of a dropped list item", async () => {
+  const element = mount("hole-first-list");
+
+  element.setState({ items: ["x"] });
+  await tick();
+
+  expect(element.shadowRoot.querySelector("div").textContent).toBe("Ax-");
+});
+
+it("should not render after the element is removed", async () => {
+  const element = mount("zombie-element");
+
+  element.remove();
+  element.setState({ count: 1 });
+  await tick();
+
+  expect(element.updates).toBe(1);
+  expect(element.effects).toBe(0);
+  expect(element.shadowRoot.querySelector("p")).toHaveTextContent("0");
+});
+
+it("should release a ref when its node goes away", async () => {
+  const swap = mount("ref-swap");
+
+  expect(swap.target.current).toBe(swap.shadowRoot.querySelector("p"));
+
+  swap.setState({ on: false });
+  await tick();
+
+  expect(swap.target.current).toBe(null);
+
+  const drop = mount("ref-drop");
+
+  expect(drop.target.current).toBe(drop.shadowRoot.querySelector("p"));
+
+  drop.setState({ keep: false });
+  await tick();
+
+  expect(drop.target.current).toBe(null);
 });


### PR DESCRIPTION
An audit of the renderer found five dom-corrupting bugs; a code review of those fixes found two more. All seven are fixed here.

## Fixes

| Bug | Symptom | Fix |
|---|---|---|
| Template swap | `render()` returning a different template reused the first skeleton, so new values landed in the old holes | compare the strings identity, re-instantiate |
| Scheduler | `disconnectedCallback` left `_t` set, so a moved element never scheduled again | reset `_t`, and gate the frame on `isConnected` so a removed element still cannot render |
| List order | an item that changed shape was inserted before the end anchor | insert before the next item, and fill a nested instance before taking its node list, so both the insertion point and the removal list count the nodes its own holes produced |
| Ref | `ref=${null}` threw and killed the render | null safe, and a ref releases its node when the value goes away or its skeleton is discarded |
| Mixed statics | `class="a ${null} b"` printed `a null b` | nullish renders `""` |

## Tests

8 new or rewritten tests. Each fix was reverted individually against the final source to confirm its test fails without it. 45/45 pass, biome clean, `src/index.js` at 100% line coverage.

Two of these came from reviewing the first round: the list fix was incomplete (an item template starting with a hole still misplaced, and its nodes leaked on removal), and the moved-in-the-dom test passed even with its own fix reverted.

## Size

1412 -> 1472 bytes gzipped. The 60 bytes of fixes are partly paid for by mangling the reserved `_` members at build time and shortening the hot paths. Terser would give 24 more bytes but adds a build dependency, so it was skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qgni6KcJYzyg1N9BhvKmm8